### PR TITLE
Query fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 test_daniel.py
 exam_tester_m1_with_delete.py
 m1_tester_with_delete.py
+test1.py

--- a/lstore/index.py
+++ b/lstore/index.py
@@ -33,13 +33,14 @@ class Index:
         self.benchmark_mode = benchmark_mode
         self.debug_mode = debug_mode
 
-        self.create_index(column_number=table.primary_key, ordered=True)
+        self.create_index(column_number=table.primary_key, ordered=False)
         
 
     def locate(self, column: int, value):
         """
         returns the location of all records with the given value on column "column"
         """
+        self._apply_maintenance(column)
         if column >= len(self.indices) or column < 0:
             raise ColumnDoesNotExist
 
@@ -59,6 +60,7 @@ class Index:
         
         returns list of (value, rid) pairs
         """
+        self._apply_maintenance(column)
         self.usage_histogram[column][1] += 1
 
         if self.indices[column]:

--- a/lstore/query.py
+++ b/lstore/query.py
@@ -198,13 +198,16 @@ class Query:
         #         found_rids.append(rid)
 
         found_rids = self.table.index.locate(column=self.table.primary_key, value=primary_key)
-        other_rids = self.table.index.locate(column=self.table.primary_key, value=columns[self.table.primary_key])
-        
-        # Verify that changing the primary key does not result in an existing primary key
-        if (isinstance(other_rids, list)):
-            if (len(other_rids) > 0):
-                if (other_rids[0] not in found_rids):
-                    return False
+
+        # In this case, the primary key itself is being updated, which requires extra checks
+        if (primary_key != columns[self.table.primary_key]):
+            other_rids = self.table.index.locate(column=self.table.primary_key, value=columns[self.table.primary_key])
+            
+            # Verify that changing the primary key does not result in an existing primary key
+            if (isinstance(other_rids, list)):
+                if (len(other_rids) > 0):
+                    if (other_rids[0] not in found_rids):
+                        return False
 
         relevant_rids = []
 

--- a/lstore/query.py
+++ b/lstore/query.py
@@ -79,7 +79,7 @@ class Query:
             pkv = self.table[pk]
 
             # If the value is not null, it exists already
-            if (pkv != None):
+            if (pkv is not None):
                 return False
         except:
             pass

--- a/lstore/table.py
+++ b/lstore/table.py
@@ -238,7 +238,7 @@ class Table:
 
         # Use the internal Index to find a record
         res = self.index.locate(self.primary_key, primary_key)[0]
-        return res[0]
+        return res
 
     def __len__(self):
         """Get the total number of Records


### PR DESCRIPTION
This fixes two issues with queries:

1. Inserting an existing primary key is defined as an invalid operation
  * Handling this requires checking if the primary key already exists
2. Updating an existing record's primary key to one that already exists is invalid
  * Handling this requires checking both that the new updated primary key exists, and also is not the same as the record that is being updated

This should be also verified with new tests designed around these constraints.