### PR TITLE
LockManager Suggestions

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,6 +25,10 @@ class Config:
     tps_and_brid_column_idx = 4
     benchmark_mode = False
 
+    # Lock types
+    SHARED_LOCK = 0
+    EXCLUSIVE_LOCK = 1
+
     # Best time to insert 100_000 random items into a b+ tree with minimum_degree.
     # 200 1.5865
     # 150 1.5878


### PR DESCRIPTION
## LockManager Changes
Changed the `LockManager` class to handle the following:
* A `Transaction` may request locks which are identical to ones already granted
  * This is valid behavior meaning the `LockManager` must keep track of ownership
* A `Transaction` may request a lock of higher priority even when granted a lower priority lock *(ex. upgrade S-Lock to X-Lock)*
* `Transactions` need to be able to remove all of their locks at once when committing

The `LockManager` now keeps a dictionary of `x_locks` and `s_locks` which are subtly different:
* `x_locks` stores a dictionary of key - `Transaction` pairs, since there can only be one associated `Transaction` for a specific X-Lock
* `s_locks` stores a dictionary of key - set pairs where the set stores `Transactions` associated with the S-Lock

In addition, the `LockManager` also stores a dictionary called `transaction_dictionary` which keeps track of the keys that a specific `Transaction` currently owns.  This makes releasing all of those locks at once much easier.

The internal mutex (`lock`) is only used when trying to obtain or release locks.

## Configuration Changes
The `config.py` file now maintains a list of lock constants which makes it easier to identify in code which lock is being used.
* `Config.SHARED_LOCK` - Refers to an S-Lock
* `Config.EXCLUSIVE_LOCK` - Refers to an X-Lock