### PR TITLE
Implemented Backoff

### DIFF
--- a/lstore/transaction.py
+++ b/lstore/transaction.py
@@ -1,3 +1,7 @@
+# System Imports
+import time
+
+# Local Imports
 from lstore.table import Table, Record
 from lstore.index import Index
 from lstore.wrapper import QueryWrapper
@@ -96,6 +100,9 @@ class Transaction:
 
         # Release all held locks
         self.__release_all()
+
+        # Force a context switch
+        time.sleep(0)
 
         return (False if not failure else None)
 


### PR DESCRIPTION
Backoff forces a context switch from the OS to a new thread after a transaction aborts.  This makes it more likely that a thread that is doing useful work will be focused.